### PR TITLE
Czytanie rozdzielczości wczytanego obrazka

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@ import numpy as np
 from skimage import img_as_ubyte
 
 
-def findCoins(img):
+def findCoins(img,surArea):
     contours = []
     gray = cv2.cvtColor(img,cv2.COLOR_BGR2GRAY)
     ret, thresh = cv2.threshold(gray,0,255,cv2.THRESH_BINARY_INV+cv2.THRESH_OTSU)
@@ -15,7 +15,7 @@ def findCoins(img):
         approx = cv2.approxPolyDP(cnt, .03 * cv2.arcLength(cnt, True), True)
         if len(approx) > 3:
             area = cv2.contourArea(cnt)
-            if 5000 < area <20000:
+            if 0.01*surArea < area < 0.04*surArea:
                 (x, y), rad = cv2.minEnclosingCircle(cnt)
                 rad=rad*0.9
                 area2 = np.pi*pow(rad,2)
@@ -25,14 +25,18 @@ def findCoins(img):
                     cv2.circle(img, (int(x), int(y)), 2, (0, 0, 255), 3)
     return contours
 
-def findBills(img):
+def findBills(img,surArea):
     contours = []
     
     return contours
     
-image = cv2.imread('money.png')
-coins = findCoins(image)
-bills = findBills(image)
+image = cv2.imread('money.jpg',0)
+rows, cols = image.shape
+nrows = cv2.getOptimalDFTSize(rows)
+ncols = cv2.getOptimalDFTSize(cols)
+image = cv2.imread('money.jpg')
+coins = findCoins(image, nrows*ncols)
+bills = findBills(image, nrows*ncols)
 cv2.imshow('image', image)
 cv2.waitKey(0)
 cv2.destroyAllWindows()


### PR DESCRIPTION
Pozwala to na dostosowanie ograniczeń w odczytywanych elementach przy użyciu findContours w zależności od rozdzielczości grafiki.